### PR TITLE
Add license information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
   "repository": {
     "type": "git",
     "url": "http://github.com/mbostock/rw.git"
-  }
+  },
+  "license": "BSD"
 }


### PR DESCRIPTION
Adds the license information to the `package.json`, so that it becomes visible and searchable in `npm`.